### PR TITLE
https://github.com/paypal/paypalhttp_java/issues/7

### DIFF
--- a/paypalhttp/src/main/java/com/paypal/http/Encoder.java
+++ b/paypalhttp/src/main/java/com/paypal/http/Encoder.java
@@ -108,6 +108,7 @@ public class Encoder {
 	}
 
 	private Serializer serializer(String contentType) {
+		contentType = contentType.toLowerCase();
 		if (contentType.contains(";")) {
 			contentType = contentType.split(";")[0];
 		}

--- a/paypalhttp/src/test/java/com/paypal/http/EncoderTest.java
+++ b/paypalhttp/src/test/java/com/paypal/http/EncoderTest.java
@@ -92,6 +92,19 @@ public class EncoderTest {
 	}
 
 	@Test
+	public void testEncoder_decode_json_case_insensitive() throws IOException {
+		String response = "{\"name\":\"Brian Tree\"}";
+		Headers headers = new Headers();
+		headers.header("Content-Type", "application/JSON");
+
+		Encoder encoder = new Encoder();
+
+		Zoo s = encoder.deserializeResponse(new ByteArrayInputStream(response.getBytes()), Zoo.class, headers);
+
+		assertEquals(s.name, "Brian Tree");
+	}
+
+	@Test
 	public void testEncoder_decode_json_withCharset() throws IOException {
 		String response = "{\"name\":\"Brian Tree\"}";
 		Headers headers = new Headers();


### PR DESCRIPTION
Unit test + fix for https://github.com/paypal/paypalhttp_java/issues/7 (be tolerant to case sensitive content type)

According to related RFC, there are no retrictions on Content-Type, so it can be both uppercase or lowercase in headers.

https://tools.ietf.org/html/rfc7231#section-3.1.1.5
https://tools.ietf.org/html/rfc2046#section-4.5