### PR TITLE
check escaper for the key barrier

### DIFF
--- a/paypalhttp/src/main/java/com/paypal/http/serializer/Json.java
+++ b/paypalhttp/src/main/java/com/paypal/http/serializer/Json.java
@@ -21,6 +21,8 @@ public class Json implements Serializer {
 	private static final char KEY_DELIMITER = ':';
 	private static final char PAIR_DELIMITER = ',';
 	private static final char KEY_BARRIER = '"';
+	private static final char KEY_ESCAPER = 92; // '\' the backslash value
+
 
 	@Override
 	public String contentType() {
@@ -398,18 +400,29 @@ public class Json implements Serializer {
 
 	private SearchResult extractNextStringToken(char[] s, int i) {
 		int startIndex = i;
-
-		if (s[i+1] == KEY_BARRIER) {
+		//also need to check whether this key barrier is escaped or not
+		if (s[i+1] == KEY_BARRIER && !isEscaped(s, i+1)) {
 			i += 2;
 		} else {
 			do {
 				i++;
-			} while(s[i] != KEY_BARRIER);
+			} while(s[i] != KEY_BARRIER || isEscaped(s,i));
 			i++;
 		}
 
 		String val = new String(s, startIndex, i - startIndex);
 		return new SearchResult(i, val);
+	}
+
+	//return true if the character is escaped.
+	private boolean isEscaped(char[] s, int i){
+		//  from the API \" will be send as \\\"
+		if(i - 1 >= 0){
+			return (s[i -1] == KEY_ESCAPER);
+		} else{
+			return false;
+		}
+
 	}
 
 	private SearchResult extractNextValueToken(char[] s, int i) {

--- a/paypalhttp/src/test/java/com/paypal/http/serializer/JsonTest.java
+++ b/paypalhttp/src/test/java/com/paypal/http/serializer/JsonTest.java
@@ -244,6 +244,36 @@ public class JsonTest {
 		assertEquals("lake", zoo.animal.locales.get(1));
 	}
 
+    @Test()
+    public void testJson_createsAnObjectWithEscapeCharacter() throws IOException {
+		ArrayList<String> fishLocales = new ArrayList<>();
+		fishLocales.add("ocean");
+		fishLocales.add("lake");
+
+		Zoo.Animal fish = new Zoo.Animal(
+				null,
+				0,
+				0,
+				null,
+				fishLocales,
+				false
+		);
+
+		// create a object with input value of double quote and three back slash
+		Zoo zoo = new Zoo(
+				"test \\\", ",
+				1,
+				fish
+		);
+
+		String serializedZoo = new Json().serialize(zoo);
+        zoo  = new Json().decode(serializedZoo, Zoo.class);
+
+        assertEquals(zoo.name, "test \\\", ");
+        assertEquals( zoo.animal.locales.get(0),"ocean");
+        assertEquals(zoo.animal.locales.get(1),"lake");
+    }
+
 	@Model
 	@ListOf(listClass = Zoo.class)
 	public static class ZooList extends ArrayList<Zoo> {


### PR DESCRIPTION
this is related to a paypal existing bug, where the Java SDK can not deserialize certain response 

where the customer input the given string in the request
"C/ Dinamarca "IPEX", 2"

And in order to send the string correctly, the SDK caller need to escape the special character,
the input string will have to be 
"C/ Dinamarca \ \ \ "IPEX \ \ \ ", 2"

SDK will escape one backslash, and send the following to the API 
"C/ Dinamarca \  "IPEX  \ ", 2"

when the API successfully process the request, it will send 
 "C/ Dinamarca \ \ \ "IPEX \ \ \ ", 2 "

when we deserialize the JSON string, we are using the double quote as the ending indicator, However, it will fail if the responses contain a double quote that is supposed to be escaped, and thus only process "C/ Dinamarca \ \ \ " instead of the whole string. 


